### PR TITLE
pin version of oddstr13/jprm to specific commit

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -30,7 +30,7 @@ jobs:
         updateFile: true
     - name: "JPRM: Build"
       id: jrpm
-      uses: oddstr13/jellyfin-plugin-repository-manager@master
+      uses: oddstr13/jellyfin-plugin-repository-manager@b9e92867a6aa279d611a5ea80cf61f6358838c39
       with:
         version: "0.0.0.9000"
         verbosity: debug


### PR DESCRIPTION
instead of the `master` branch - for security