### PR TITLE
ci: ignore prereleases when publishing manifest

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Publish Plugin Manifest
       uses: Kevinjil/jellyfin-plugin-repo-action@v0.4.0
       with:
-        ignorePrereleases: false
+        ignorePrereleases: true
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ github.repository }}
         pagesBranch: manifest-release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Publish Plugin Manifest
       uses: Kevinjil/jellyfin-plugin-repo-action@v0.4.0
       with:
-        ignorePrereleases: false
+        ignorePrereleases: true
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ github.repository }}
         pagesBranch: manifest-release


### PR DESCRIPTION
Early releases gave invalid version strings:

https://github.com/9p4/jellyfin-plugin-sso/blob/b8439bc710daa0fb137d8f639199a9dfee924bd6/manifest.json#L59-L72

I've marked these as prerelease & valid installation candidates as releases, and instructed jprm action to ignore them