### PR TITLE
fix(authelia): Fix typo in authelia provider config

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -52,7 +52,7 @@ identity_providers:
         secret: <redacted>
         authorization_policy: one_factor
         redirect_uris:
-          - https://jellyfin.example.com/sso/OID/r/authelia
+          - https://jellyfin.example.com/sso/OID/p/authelia
 ```
 
 ### Jellyfin's Config


### PR DESCRIPTION
Fix for a very confusing typo in the docs

https://jellyfin.example.com/sso/OID/r/authelia doesnt work but /p/authelia works like charm. 