### PR TITLE
build: ignore .vscode entirely in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -448,7 +448,4 @@ $RECYCLE.BIN/
 ## Visual Studio Code
 ##
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode


### PR DESCRIPTION
Per https://github.com/9p4/jellyfin-plugin-sso/issues/17 , it doesn't look like @9p4 wants any vscode specific artifacts in the repo.

In order to keep my workflows in sync across different machines, I've decided maintain my .vscode for this project in its own repository https://github.com/matthewstrasiotto/jellyfin-plugin-sso-vscode which i clone to `.vscode` in this repo.

As a result, I've expanded the gitignore patterns to fully ignore the `.vscode` directory