### PR TITLE
ci: :construction_worker: keep our own build workflow and reference that in publish.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        required: false
+        default: "6.0.x"
+        description: "The .NET version to setup for the build"
+        type: string
+      dotnet-target:
+        required: false
+        default: "net6.0"
+        description: "The .NET target to set for JPRM"
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "${{ inputs.dotnet-version }}"
+
+      - name: Build Jellyfin Plugin
+        uses: oddstr13/jellyfin-plugin-repository-manager@b9e92867a6aa279d611a5ea80cf61f6358838c39
+        id: jprm
+        with:
+          dotnet-target: "${{ inputs.dotnet-target }}"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3
+        with:
+          name: build-artifact
+          retention-days: 30
+          if-no-files-found: error
+          path: ${{ steps.jprm.outputs.artifact }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/build.yaml@30fd723cc3bafc4457a4a85be3cdbee2f3e2013b
+    uses: ./.github/workflows/build.yml
     with:
       dotnet-version: "6.0.*"
       dotnet-target:  "net6.0"


### PR DESCRIPTION
Squash of
- ci: :construction_worker: keep our own build workflow and reference that in publish.yml
- ci: :pushpin: pin actions/checkout,setup-dotnet odstr13/jellyfin-plugin-repo-manager to approved version

This will still fail because actions/upload-artifact isnt approved.

Getting kind of tilted trying to contribute to ci when the upstream CI settings fight me at every turn