### PR TITLE
fix: don't include port in redirect URL for 80 and 443

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -948,7 +948,19 @@ public class SSOController : ControllerBase
 
     private string GetRequestBase()
     {
-        return Request.Scheme + "://" + Request.Host + Request.PathBase;
+        int requestPort = Request.Host.Port ?? -1;
+        if ((requestPort == 80 && string.Equals(Request.Scheme, "http", StringComparison.OrdinalIgnoreCase)) || (requestPort == 443 && string.Equals(Request.Scheme, "https", StringComparison.OrdinalIgnoreCase)))
+        {
+            requestPort = -1;
+        }
+
+        return new UriBuilder
+        {
+            Scheme = Request.Scheme,
+            Host = Request.Host.Host,
+            Port = requestPort,
+            Path = Request.PathBase
+        }.ToString().TrimEnd('/');
     }
 
     private ContentResult ReturnError(int code, string message)


### PR DESCRIPTION
Skip port number in redirect URLs during the following conditions
 - The request scheme is http and request port is 80
 - The request scheme is https and request port is 443

This creates redirect urls as https://server/path instead of https://server:443/path

