### PR TITLE
docs: 📝 add authentik redirect uri step

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -113,6 +113,7 @@ Now we can add this property mapping to authentik's Jellyfin OAuth provider:
   ![image](img/authentik-config-04.jpg)
 
 - Edit / Update your Jellyfin OAuth provider
+- Verify your **"Redirect URIs/Origins (RegEx)"** follows the format: `https://domain.tld/sso/OID/r/Authentik`.
 - Under **"Advanced Protocol Settings"**, add the **Group Membership** Scope
 
   ![image](img/authentik-config-05.jpg)


### PR DESCRIPTION
Adding `redirect_url` end-point so users do not have to analyze the code for this line https://github.com/9p4/jellyfin-plugin-sso/blob/c6cac45004a32a7d8cf5863102ef947f792ed021/SSO-Auth/Api/SSOController.cs#L67