### PR TITLE
fix: use /start/ link instead of /p/ in /SSOViews/linking

### DIFF
--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -60,7 +60,7 @@ const ssoConfigLinking = {
       add_provider.classList.add("sso-provider");
 
       add_provider.href = ApiClient.getUrl(
-        `/SSO/${provider_mode}/p/${provider_name}?isLinking=true`,
+        `/SSO/${provider_mode}/start/${provider_name}?isLinking=true`,
       );
 
       container.appendChild(provider_config);


### PR DESCRIPTION
Fixes #138 