### PR TITLE
Remove jellyfin_credentials before loading iframe

### DIFF
--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -453,6 +453,9 @@ async function link(request) {
 }
 
 async function main() {
+    localStorage.removeItem('jellyfin_credentials');
+    document.getElementById('iframe-main').src = '" + baseUrl + @"/web/index.html';
+
     var data = '" + data + @"';
     while (localStorage.getItem(""_deviceId2"") == null ||
         localStorage.getItem(""jellyfin_credentials"") == null ||
@@ -501,6 +504,6 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 // https://stackoverflow.com/a/25435165
-</script><iframe class='docs-texteventtarget-iframe' sandbox='allow-same-origin allow-forms allow-scripts' src='" + baseUrl + "/web/index.html' style='position: absolute;width:0;height:0;border:0;'></iframe></body></html>";
+</script><iframe id='iframe-main' class='docs-texteventtarget-iframe' sandbox='allow-same-origin allow-forms allow-scripts' src='' style='position: absolute;width:0;height:0;border:0;'></iframe></body></html>";
     }
 }


### PR DESCRIPTION
Due to Safari's aggressive caching updated `jellyfin_credentials` were not used. They were overwritten with the old credentials instead. This fix removes `jellyfin_credentials` first, then let's iframe load and create new `jellyfin_credentials` with no access token. After this we update it and login succeeds.

Resolves https://github.com/9p4/jellyfin-plugin-sso/discussions/162
Closes https://github.com/9p4/jellyfin-plugin-sso/issues/113