### PR TITLE
Update version in SSO-Auth.csproj

### DIFF
--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.SSO_Auth</RootNamespace>
-    <AssemblyVersion>3.3.0.0</AssemblyVersion>
-    <FileVersion>3.3.0.0</FileVersion>
+    <AssemblyVersion>3.5.2.3</AssemblyVersion>
+    <FileVersion>3.5.2.3</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
This is what is appearing in the Jellyfin UI when I put (a symlink to my own build of, but with the ~same meta.json) jellyfin-plugin-sso at `/var/lib/jellyfin/plugins/sso`. It seems to be due to the assembly version not matching the actual version of the software. But I am wondering if it's actually just Jellyfin ignoring my meta.json :P

![image](https://github.com/9p4/jellyfin-plugin-sso/assets/6652840/841aabd3-f213-4a07-acee-b85fda4761c3)
