### PR TITLE
update authelia example to authelia v4.38

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -47,10 +47,11 @@ identity_providers:
   oidc:
     # hmac secret and private key given by env variables
     clients:
-      - id: jellyfin
-        description: My media server
+      - client_id: jellyfin
+        client_name: My media server
         # Client secret should be randomly generated
-        secret: <redacted>
+        client_secret: <redacted>
+        token_endpoint_auth_method: client_secret_post
         authorization_policy: one_factor
         redirect_uris:
           - https://jellyfin.example.com/sso/OID/redirect/authelia

--- a/providers.md
+++ b/providers.md
@@ -39,9 +39,9 @@ FolderRoleMapping: []
 Authelia is simple to configure, and RBAC is straightforward.
 
 ### Authelia's Config
-
 Below is the `identity_providers` section of an Authelia config:
 
+### Authelia v4.38 and above
 ```yaml
 identity_providers:
   oidc:
@@ -52,6 +52,21 @@ identity_providers:
         # Client secret should be randomly generated
         client_secret: <redacted>
         token_endpoint_auth_method: client_secret_post
+        authorization_policy: one_factor
+        redirect_uris:
+          - https://jellyfin.example.com/sso/OID/redirect/authelia
+```
+
+### Authelia v4.37 and below
+```yaml
+identity_providers:
+  oidc:
+    # hmac secret and private key given by env variables
+    clients:
+      - id: jellyfin
+        description: My media server
+        # Client secret should be randomly generated
+        secret: <redacted>
         authorization_policy: one_factor
         redirect_uris:
           - https://jellyfin.example.com/sso/OID/redirect/authelia


### PR DESCRIPTION
Hello, this small PR will update the authelia example configuration to the latest authelia version.

Authelia v4.38 will default to using the client_secret_basic authentication method, as described in the [release post](https://www.authelia.com/blog/4.38-release-notes/) to follow the OIDC specification.

Not setting the [token_endpoint_auth_method](https://www.authelia.com/configuration/identity-providers/openid-connect/clients/#token_endpoint_auth_method) to `client_secret_post` will generate the following error:
```
Access Request failed with error: Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). 
The request was determined to be using 'token_endpoint_client_auth_method' method 'client_secret_post', however the OAuth 2.0 client does not support this method. 
The registered client with id 'jellyfin' only supports 'token_endpoint_client_auth_method' method 'client_secret_basic'.
```

Please note that this configuration change is not backwards compatible to any version prior to v4.38.

I am open to any feedback regarding this change. If you don't experience the same issue while using authelia v4.38 please leave a comment down below.
