### PR TITLE
Update configPage.html - Provider description

### DIFF
--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -531,16 +531,18 @@
                   <div class="fieldDescription">
                     The provider then gets assigned to the user after they
                     have logged in. If it is not set, nothing is changed.<br />With
-                    the following provider, a user can login with SSO but is still 
+                    the following provider, a user can login with SSO but is still
                     able to log in via normal password-based login form:<br />
                     <code
                       >Jellyfin.Plugin.LDAP_Auth.LdapAuthenticationProviderPlugin</code
-                    ><br />IMPORTANT: If this provider is used, ALL newly created Jellyfin users
-                    have no password set and login without password is possible!<br />
-                    If you prefer to use only SSO based logins, you should prefer this provider:<br />
+                    ><br />IMPORTANT: If this provider is used, ALL newly created
+                    Jellyfin users have no password set and login without password
+                    is possible!<br />If you prefer to use only SSO based logins,
+                    you should prefer this provider:<br />
                     <code
                       >Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider</code
-                    ><br /><br />You can still use QuickConnect for clients that don't support SSO based logins.
+                    ><br /><br />You can still use QuickConnect for clients
+                    that don't support SSO based logins.
                   </div>
                 </div>
 

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -541,8 +541,7 @@
                     you should prefer this provider:<br />
                     <code
                       >Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider</code
-                    ><br /><br />You can still use QuickConnect for clients
-                    that don't support SSO based logins.
+                    ><br /><br />You can still use QuickConnect for clients that don't support SSO based logins.
                   </div>
                 </div>
 

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -541,7 +541,8 @@
                     you should prefer this provider:<br />
                     <code
                       >Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider</code
-                    ><br /><br />You can still use QuickConnect for clients that don't support SSO based logins.
+                    ><br /><br />You can still use QuickConnect for clients that don't support
+                    SSO based logins.
                   </div>
                 </div>
 

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -529,14 +529,18 @@
                     class="sso-text"
                   />
                   <div class="fieldDescription">
-                    The set provider then gets assigned to the user after they
-                    have logged in. If it is not set, nothing is changed. With
-                    this, a user can login with SSO but is still able to log in
-                    via other providers later.<br />A common option is
+                    The provider then gets assigned to the user after they
+                    have logged in. If it is not set, nothing is changed.<br />With
+                    the following provider, a user can login with SSO but is still 
+                    able to log in via normal password-based login form:<br />
+                    <code
+                      >Jellyfin.Plugin.LDAP_Auth.LdapAuthenticationProviderPlugin</code
+                    ><br />IMPORTANT: If this provider is used, ALL newly created Jellyfin users
+                    have no password set and login without password is possible!<br />
+                    If you prefer to use only SSO based logins, you should prefer this provider:<br />
                     <code
                       >Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider</code
-                    >
-                    for the default provider.
+                    ><br /><br />You can still use QuickConnect for clients that don't support SSO based logins.
                   </div>
                 </div>
 


### PR DESCRIPTION
I just accidentally discovered that the recommended default provider setting can cause a serious security issue:
If `Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider` is used, every newly created user has no password by default. Therefore, passwordless login is possible for all these users. I think it would be wise to at least mention this as it is not really mentioned at all.

In addition, I think it would be good to mention `Jellyfin.Plugin.LDAP_Auth.LdapAuthenticationProviderPlugin` as another option that might be more suitable for most use cases.