### PR TITLE
fix: consistently use OpenID instead of OID on the config page

### DIFF
--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -73,7 +73,7 @@
               <div class="collapseContent">
                 <div class="selectContainer">
                   <label class="selectLabel" for="selectProvider"
-                    >Name of OID Provider:
+                    >Name of OpenID Provider:
                   </label>
                   <select
                     is="emby-select"
@@ -123,7 +123,7 @@
                   <label
                     class="inputLabel inputLabelUnfocused"
                     for="OidProviderName"
-                    >Name of OID Provider:</label
+                    >Name of OpenID Provider:</label
                   >
                   <input
                     is="emby-input"
@@ -133,12 +133,12 @@
                     class="sso-text"
                   />
                   <div class="fieldDescription">
-                    The name used by Jellyfin to identify the OID provider.
+                    The name used by Jellyfin to identify the OpenID provider.
                     <br />
-                    If an OID provider with a matching name does not exist, a
+                    If an OpenID provider with a matching name does not exist, a
                     new provider with this name will be created.
                     <br />
-                    If an OID provider with a matching name already exists, the
+                    If an OpenID provider with a matching name already exists, the
                     settings for that provider will be updated.
                   </div>
                 </div>
@@ -146,7 +146,7 @@
                   <label
                     class="inputLabel inputLabelUnfocused"
                     for="OidEndpoint"
-                    >OID Endpoint:</label
+                    >OpenID Endpoint:</label
                   >
                   <input
                     is="emby-input"
@@ -181,7 +181,7 @@
                 </div>
                 <div class="inputContainer">
                   <label class="inputLabel inputLabelUnfocused" for="OidSecret"
-                    >OID Secret:</label
+                    >OpenID client secret:</label
                   >
                   <input
                     is="emby-input"
@@ -191,7 +191,7 @@
                     class="sso-text"
                   />
                   <div class="fieldDescription">
-                    The OpenID secret. Randomly generated & shared.
+                    The OpenID client secret. Randomly generated & shared.
                   </div>
                 </div>
 


### PR DESCRIPTION
On the config page use consistently `OpenID` instead of `OID`.