### PR TITLE
Avatar via OIDC Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ These all require authorization. Append an API key to the end of the request: `c
     - Leave empty to only request the default scopes.
   - `defaultProvider`: string. The set provider then gets assigned to the user after they have logged in. If it is not set, nothing is changed. With this, a user can login with SSO but is still able to log in via other providers later. See the `Unregister` endpoint.
   - `defaultUsernameClaim`: string. The provider will use the claim to create the users' usernames. If not set, it fallbacks to `preferred_username`.
+  - `avatarUrlFormat`: string. The URL format for the users avatars. OIDC claims can be used by using the `@{claim_type}` syntax. If not set, the avatars won't change. 
   - `disableHttps`: boolean. Determines whether the OpenID discovery endpoint requires HTTPS.
   - `doNotValidateEndpoints`: boolean. Determines whether the OpenID discovery process will validate endpoints. This may be required for Google.
   - `doNotValidateIssuerName`: boolean. Determines whether the OpenID discovery process will validate the OpenID issuer name.

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Net.Mime;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
@@ -12,14 +14,15 @@ using Jellyfin.Plugin.SSO_Auth.Config;
 using Jellyfin.Plugin.SSO_Auth.Helpers;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Net;
+using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Cryptography;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -38,6 +41,8 @@ public class SSOController : ControllerBase
     private readonly IAuthorizationContext _authContext;
     private readonly ILogger<SSOController> _logger;
     private readonly ICryptoProvider _cryptoProvider;
+    private readonly IProviderManager _providerManager;
+    private readonly IServerConfigurationManager _serverConfigurationManager;
     private static readonly IDictionary<string, TimedAuthorizeState> StateManager = new Dictionary<string, TimedAuthorizeState>();
 
     /// <summary>
@@ -48,13 +53,24 @@ public class SSOController : ControllerBase
     /// <param name="authContext">Instance of the <see cref="IAuthorizationContext"/> interface.</param>
     /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
     /// <param name="cryptoProvider">Instance of the <see cref="ICryptoProvider"/> interface.</param>
-    public SSOController(ILogger<SSOController> logger, ISessionManager sessionManager, IUserManager userManager, IAuthorizationContext authContext, ICryptoProvider cryptoProvider)
+    /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
+    /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+    public SSOController(
+        ILogger<SSOController> logger,
+        ISessionManager sessionManager,
+        IUserManager userManager,
+        IAuthorizationContext authContext,
+        ICryptoProvider cryptoProvider,
+        IProviderManager providerManager,
+        IServerConfigurationManager serverConfigurationManager)
     {
         _sessionManager = sessionManager;
         _userManager = userManager;
         _authContext = authContext;
         _cryptoProvider = cryptoProvider;
         _logger = logger;
+        _providerManager = providerManager;
+        _serverConfigurationManager = serverConfigurationManager;
         _logger.LogInformation("SSO Controller initialized");
     }
 
@@ -116,6 +132,13 @@ public class SSOController : ControllerBase
 
             StateManager[state].EnableLiveTv = config.EnableLiveTv;
             StateManager[state].EnableLiveTvManagement = config.EnableLiveTvManagement;
+
+            if (config.AvatarUrlFormat is not null)
+            {
+                StateManager[state].AvatarURL = result.User.Claims.Aggregate(
+                    config.AvatarUrlFormat,
+                    (s, claim) => s.Contains($"@{{{claim.Type}}}") ? s.Replace($"@{{{claim.Type}}}", claim.Value) : s);
+            }
 
             foreach (var claim in result.User.Claims)
             {
@@ -421,7 +444,7 @@ public class SSOController : ControllerBase
                 {
                     Guid userId = await CreateCanonicalLinkAndUserIfNotExist("oid", provider, kvp.Value.Username);
 
-                    var authenticationResult = await Authenticate(userId, kvp.Value.Admin, config.EnableAuthorization, config.EnableAllFolders, kvp.Value.Folders.ToArray(), kvp.Value.EnableLiveTv, kvp.Value.EnableLiveTvManagement, response, config.DefaultProvider?.Trim())
+                    var authenticationResult = await Authenticate(userId, kvp.Value.Admin, config.EnableAuthorization, config.EnableAllFolders, kvp.Value.Folders.ToArray(), kvp.Value.EnableLiveTv, kvp.Value.EnableLiveTvManagement, response, config.DefaultProvider?.Trim(), kvp.Value.AvatarURL)
                         .ConfigureAwait(false);
                     return Ok(authenticationResult);
                 }
@@ -686,7 +709,7 @@ public class SSOController : ControllerBase
 
             Guid userId = await CreateCanonicalLinkAndUserIfNotExist("saml", provider, samlResponse.GetNameID());
 
-            var authenticationResult = await Authenticate(userId, isAdmin, config.EnableAuthorization, config.EnableAllFolders, folders.ToArray(), liveTv, liveTvManagement, response, config.DefaultProvider?.Trim())
+            var authenticationResult = await Authenticate(userId, isAdmin, config.EnableAuthorization, config.EnableAllFolders, folders.ToArray(), liveTv, liveTvManagement, response, config.DefaultProvider?.Trim(), null)
                 .ConfigureAwait(false);
             return Ok(authenticationResult);
         }
@@ -1020,7 +1043,8 @@ public class SSOController : ControllerBase
     /// <param name="enableLiveTvAdmin">Determines whether live TV can be managed by this user.</param>
     /// <param name="authResponse">The client information to authenticate the user with.</param>
     /// <param name="defaultProvider">The default provider of the user to be set after logging in.</param>
-    private async Task<AuthenticationResult> Authenticate(Guid userId, bool isAdmin, bool enableAuthorization, bool enableAllFolders, string[] enabledFolders, bool enableLiveTv, bool enableLiveTvAdmin, AuthResponse authResponse, string defaultProvider)
+    /// <param name="avatarUrl">The new avatar url for the user.</param>
+    private async Task<AuthenticationResult> Authenticate(Guid userId, bool isAdmin, bool enableAuthorization, bool enableAllFolders, string[] enabledFolders, bool enableLiveTv, bool enableLiveTvAdmin, AuthResponse authResponse, string defaultProvider, string avatarUrl)
     {
         User user = _userManager.GetUserById(userId);
         if (enableAuthorization)
@@ -1030,6 +1054,36 @@ public class SSOController : ControllerBase
             if (!enableAllFolders)
             {
                 user.SetPreference(PreferenceKind.EnabledFolders, enabledFolders);
+            }
+        }
+
+        if (avatarUrl is not null)
+        {
+            try
+            {
+                using var client = new HttpClient();
+                var extension = avatarUrl.Split(".").Last();
+                var stream = await client.GetStreamAsync(avatarUrl);
+                if (user != null)
+                {
+                    var userDataPath =
+                        Path.Combine(
+                            _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath,
+                            user.Username);
+                    if (user.ProfileImage is not null)
+                    {
+                        await _userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
+                    }
+
+                    user.ProfileImage = new ImageInfo(Path.Combine(userDataPath, "profile" + extension));
+
+                    await _providerManager.SaveImage(stream, "image/" + extension, user.ProfileImage.Path)
+                        .ConfigureAwait(false);
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e.Message);
             }
         }
 
@@ -1150,6 +1204,7 @@ public class TimedAuthorizeState
         IsLinking = false;
         EnableLiveTv = false;
         EnableLiveTvManagement = false;
+        AvatarURL = null;
     }
 
     /// <summary>
@@ -1197,4 +1252,9 @@ public class TimedAuthorizeState
     /// Gets or sets a value indicating whether the user is allowed to manage live TV.
     /// </summary>
     public bool EnableLiveTvManagement { get; set; }
+    
+    /// <summary>
+    /// Gets or set the user avatar url.
+    /// </summary>
+    public string AvatarURL { get; set; }
 }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -294,6 +294,11 @@ public class OidConfig
     public string DefaultUsernameClaim { get; set; }
 
     /// <summary>
+    /// Gets or sets the URL format of the new user avatar.
+    /// </summary>
+    public string AvatarUrlFormat { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether HTTPS in the discovery endpoint is required.
     /// </summary>
     public bool DisableHttps { get; set; }

--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -301,12 +301,21 @@ const ssoConfigurationPage = {
 
         form_elements.text_fields.forEach((id) => {
           const value = page.querySelector("#" + id).value;
-          if (value) current_config[id] = page.querySelector("#" + id).value;
+          if (value) {
+            current_config[id] = page.querySelector("#" + id).value
+          } else {
+            current_config[id] = null;
+          }
         });
 
         form_elements.json_fields.forEach((id) => {
           const value = page.querySelector("#" + id).value;
-          if (value) current_config[id] = JSON.parse(value);
+          if (value) {
+            current_config[id] = JSON.parse(value)
+          }
+          else {
+            current_config[id] = null;
+          }
         });
 
         form_elements.check_fields.forEach((id) => {

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -559,6 +559,24 @@
                   </div>
                 </div>
 
+                <div class="inputContainer">
+                  <label
+                          class="inputLabel inputLabelUnfocused"
+                          for="AvatarUrlFormat"
+                  >Set avatar url format</label
+                  >
+                  <input
+                          is="emby-input"
+                          id="AvatarUrlFormat"
+                          type="text"
+                          class="sso-text"
+                  />
+                  <div class="fieldDescription">
+                    The url of the avatar with sso variable format:
+                    example : <code>https://example.com/@{user_id}.png</code>
+                  </div>
+                </div>
+
                 <div class="checkboxContainer">
                   <label>
                     <input


### PR DESCRIPTION
## Description
I've added a config field to the OIDC provider that can set the avatar of a user based on a URL template that can use Claim Types as values.

If the field is empty, the behavior is the same as it was, meaning the current avatar set by the user is kept as is.
If the field is filled, then each time a user connects with OIDC, the user avatar is updated.

## Examples

### Typical
If the oidc provider sends an `avatar_url` claim type, we can then set the AvatarURLFormat as `@{avatar_url}`

![image](https://github.com/user-attachments/assets/894bc437-810d-43e2-a216-102dec97e3d4)

### Advanced
If we use a discord linked provider that provides a `discord_id` and an `avatar` claim type, we can then set the AvatarURLFormat as  `https://cdn.discordapp.com/avatars/@{discord_id}/@{avatar}.jpg?size=512`

![image](https://github.com/user-attachments/assets/c86f1198-c57a-4b5c-8dba-6cc0801fbca4)


## Limitations
If multiple claims exists with the same claim type, only the first one will be applied to the AvatarURLFormat

## Bug fixes
- Text and JSON fields can now be emptied.
