### PR TITLE
Support DisableHttps/DoNotValidateIssuerName in SSOController.OidChallenge

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -312,6 +312,8 @@ public class SSOController : ControllerBase
             var oidEndpointUri = new Uri(config.OidEndpoint?.Trim());
             options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(oidEndpointUri.GetLeftPart(UriPartial.Authority));
             options.Policy.Discovery.ValidateEndpoints = !config.DoNotValidateEndpoints; // For Google and other providers with different endpoints
+            options.Policy.Discovery.RequireHttps = !config.DisableHttps;
+            options.Policy.Discovery.ValidateIssuerName = !config.DoNotValidateIssuerName;
             var oidcClient = new OidcClient(options);
             var state = await oidcClient.PrepareLoginAsync().ConfigureAwait(false);
             StateManager.Add(state.State, new TimedAuthorizeState(state, DateTime.Now));


### PR DESCRIPTION
I tried to get the Jellyfin SSO Plugin working locally without HTTPS, but ran into the same issue described by #76 even after checking "Disable OpenID HTTPS Discovery (Insecure)" for my configured provider. A comment on the same issue also mentioned trouble getting the configuration option to work.

Checking the code for `SSOController` I realized that `RequireHttps` and `ValidateIssuerName` are only set for `OidPost`, but not for `OidChallenge`, which is addressed by this PR. I tested the changes and could successfully log in with the communication between the plugin and my IDP running over HTTP.