### PR TITLE
fix authelia instructions

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -57,6 +57,7 @@ identity_providers:
         authorization_policy: one_factor
         redirect_uris:
           - https://jellyfin.example.com/sso/OID/redirect/authelia
+          - https://jellyfin.example.com/sso/OID/r/authelia
 ```
 
 ### Authelia v4.37 and below


### PR DESCRIPTION
This is a small (a single line in the providers.md file) fix to resolve an issue with the documentation not being correct.

The current version of the documentation causes an error when attempting to connect to Authelia, caused by the redirect_uri that gets sent being incorrect. At some point since the documentation was written, the redirect uri was changed from '/sso/OID/redirect/` to simply `/sso/OID/r/`.

When following the instructions as written, the user will encounter an error. After adding this line to my Authelia configuration and refreshing Authelia & Jellyfin, the error is gone and OIDC works as expected.