### PR TITLE
Prevent force updating username

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -772,7 +772,28 @@ public class SSOController : ControllerBase
     private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalName)
     {
         User user = null;
-        user = _userManager.GetUserByName(canonicalName);
+
+        // First try to get the user by its id in case it was already registered before
+        Guid userId = Guid.Empty;
+        try
+        {
+            userId = GetCanonicalLink(mode, provider, canonicalName);
+        }
+        catch (KeyNotFoundException)
+        {
+            userId = Guid.Empty;
+        }
+
+        // No userId found? Let's try and find the user by name instead
+        if (userId == Guid.Empty)
+        {
+            user = _userManager.GetUserByName(canonicalName);
+        }
+        else
+        {
+            user = _userManager.GetUserById(userId);
+        }
+        
         if (user == null)
         {
             _logger.LogInformation($"SSO user {canonicalName} doesn't exist, creating...");
@@ -787,7 +808,7 @@ public class SSOController : ControllerBase
             UpdateCanonicalLinkConfig(links, mode, provider);
         }
 
-        Guid userId = Guid.Empty;
+        userId = Guid.Empty;
         try
         {
             userId = GetCanonicalLink(mode, provider, canonicalName);


### PR DESCRIPTION
My changes make it so the user retrieval is first attempted using the userId. If there's no userId found yet, it'll try and find the user using the username.

This fixes the following issue:
1. Log in using SSO and create a fresh account
2. Get a random username assigned (because Cloudflare gives you an guid as a username)
3. Change the username using the web environment
4. Log out and log in using SSO again
5. Notice your username is now set to the guid again, additionally you've been given a new user account

By first trying to retrieve the user using its id, username modifications are supported.

Please note that I've not tested these changes myself, but I'm pretty confident these changes will work.

Should fix the following issues: 
https://github.com/9p4/jellyfin-plugin-sso/issues/146
https://github.com/9p4/jellyfin-plugin-sso/issues/75