### PR TITLE
Control access to all libraries by default when enableAuthorization = false

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1089,6 +1089,10 @@ public class SSOController : ControllerBase
                 user.SetPreference(PreferenceKind.EnabledFolders, enabledFolders);
             }
         }
+        else
+        {
+            user.SetPermission(PermissionKind.EnableAllFolders, enableAllFolders);
+        }
 
         if (avatarUrl is not null)
         {

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1080,18 +1080,16 @@ public class SSOController : ControllerBase
     private async Task<AuthenticationResult> Authenticate(Guid userId, bool isAdmin, bool enableAuthorization, bool enableAllFolders, string[] enabledFolders, bool enableLiveTv, bool enableLiveTvAdmin, AuthResponse authResponse, string defaultProvider, string avatarUrl)
     {
         User user = _userManager.GetUserById(userId);
+
+        user.SetPermission(PermissionKind.EnableAllFolders, enableAllFolders);
+
         if (enableAuthorization)
         {
             user.SetPermission(PermissionKind.IsAdministrator, isAdmin);
-            user.SetPermission(PermissionKind.EnableAllFolders, enableAllFolders);
             if (!enableAllFolders)
             {
                 user.SetPreference(PreferenceKind.EnabledFolders, enabledFolders);
             }
-        }
-        else
-        {
-            user.SetPermission(PermissionKind.EnableAllFolders, enableAllFolders);
         }
 
         if (avatarUrl is not null)

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1081,7 +1081,11 @@ public class SSOController : ControllerBase
     {
         User user = _userManager.GetUserById(userId);
 
-        user.SetPermission(PermissionKind.EnableAllFolders, enableAllFolders);
+        var existingAllFoldersPermission = user.Permissions.FirstOrDefault(p => p.Kind == PermissionKind.EnableAllFolders)?.Value;
+        if (existingAllFoldersPermission is null)
+        {
+            user.SetPermission(PermissionKind.EnableAllFolders, enableAllFolders);
+        }
 
         if (enableAuthorization)
         {

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1081,11 +1081,7 @@ public class SSOController : ControllerBase
     {
         User user = _userManager.GetUserById(userId);
 
-        var existingAllFoldersPermission = user.Permissions.FirstOrDefault(p => p.Kind == PermissionKind.EnableAllFolders)?.Value;
-        if (existingAllFoldersPermission is null)
-        {
-            user.SetPermission(PermissionKind.EnableAllFolders, enableAllFolders);
-        }
+        user.SetPermission(PermissionKind.EnableAllFolders, enableAllFolders);
 
         if (enableAuthorization)
         {


### PR DESCRIPTION
This PR resolves the issue https://github.com/9p4/jellyfin-plugin-sso/issues/147.
It will set `EnableAllFolders` setting to the value from `Enable All Folders` checkbox of plugin's settings. 
That allows admin to prevent full library access for new users.

So if the plugin does not control authorization and the checkbox `Enable All Folders` is set to `false` - new user will be created without full library access, and that is more secure.

By default `EnableAllFolders = true`. It will override the setting according to setting in SSO plugin `Enable All Folders`
