### PR TITLE
remove deprecated redirect uri from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ The nightly build may have new features unavailable in other builds, but **be wa
 
 ## Examples
 
-**Note that you should add both "/r/" and "/redirect/" paths to your SSO provider's configuration!**
-
 ### Creating A Login Button On The Main Page
 
 In the Jellyfin administration UI, under "General", there is a "Branding" section. In that section, add the following code in the "Login disclaimer" block (replacing `PROVIDER_NAME` and the domain):


### PR DESCRIPTION
Hi,

maintaining the authelia integration guide is becoming an increasing burden because of this sentence in the documentation.
There is a continuous influx of PRs adding this deprecated option to the documentation.

As it has been stated multiple times by you, it no longer necessary to add both redirect uris.

This PR will remove this sentence from the docs.