### PR TITLE
feat: allow setting MaxParentalRatingScore when creating users

### DIFF
--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -75,6 +75,11 @@ public class SamlConfig
     public string[] EnabledFolders { get; set; }
 
     /// <summary>
+    /// Gets or sets the user max perental rating score.
+    /// </summary>
+    public int? MaxParentalRatingScore { get; set; }
+
+    /// <summary>
     /// Gets or sets the roles that are checked to determine whether the user is an administrator.
     /// </summary>
     public string[] AdminRoles { get; set; }
@@ -202,6 +207,11 @@ public class OidConfig
     /// Gets or sets what folders should users have access to by default.
     /// </summary>
     public string[] EnabledFolders { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user max perental rating score.
+    /// </summary>
+    public int? MaxParentalRatingScore { get; set; }
 
     /// <summary>
     /// Gets or sets the roles that are checked to determine whether the user is an administrator.

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -272,6 +272,17 @@
                 </div>
 
                 <div class="inputContainer">
+                  <label class="inputLabel inputLabelUnfocused" for="MaxParentalRatingScore">Max Parental Rating Score</label>
+                  <input is="emby-input"
+                         id="MaxParentalRatingScore"
+                         type="text"
+                         class="sso-text" />
+                  <div class="fieldDescription">
+                      Set the MaxParentalRatingScore property when creating the user.
+                  </div>
+                </div>
+
+                <div class="inputContainer">
                   <label class="inputLabel inputLabelUnfocused" for="Roles"
                     >Roles:</label
                   >


### PR DESCRIPTION
Added the 'Max Parental Rating Score' setting and applied it during user creation. This has been tested with an OIDC provider on the `linuxserver/jellyfin:nightly` image.

<img width="1290" height="548" alt="image" src="https://github.com/user-attachments/assets/20c17e44-3827-4fc4-a2cb-2f72c7663702" />

Closes #295