### PR TITLE
Update providers.md with a fix on Authentik OIDC URL redirect issue

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -156,6 +156,7 @@ authentik:
 ```
 
 If you recieve the error `Error processing request.` from Jellyfin when attempting to login and the Jellyfin logs show `Error loading discovery document: Endpoint belongs to different authority` try setting `Do not validate endpoints` in the plugin settings.
+If you receive the error `Redirect URI Error` from Authentik when attempting to login and the URL of your Authentik and Jellyfin instances are `https`, the most likely cause is that the plugin by default submits redirect url in `http`. In `Scheme Override`, set it to `https`.
 
 ## Keycloak OIDC
 


### PR DESCRIPTION
When hosting Jellyfin and Authentik behind a reverse proxy such as traefik and using `https` as URL, the plugin by default submits url redirect in `http`. I added a doc to fix the issue.