### PR TITLE
fix: invalidate state immediately after auth

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -501,7 +501,7 @@ public class SSOController : ControllerBase
                         config.DefaultProvider?.Trim(),
                         kvp.Value.AvatarURL)
                         .ConfigureAwait(false);
-                    Invalidate();
+                    StateManager.Remove(kvp.Key);
                     return Ok(authenticationResult);
                 }
             }
@@ -777,7 +777,6 @@ public class SSOController : ControllerBase
                 config.DefaultProvider?.Trim(),
                 null)
                 .ConfigureAwait(false);
-            Invalidate();
             return Ok(authenticationResult);
         }
 


### PR DESCRIPTION
Hi,

This is a small follow up to: https://github.com/9p4/jellyfin-plugin-sso/commit/547eabf55f899a4bcc81643875083b054b78e60d

Because of the `now.Subtract(kvp.Value.Created).TotalMinutes > 1`  condition in the `Invalidate` method, old states aren't  invalidated if the login flow is completed in under one minute. This has the consequence that still more than one access token can be minted with the same state parameter.

Also, from what I saw, the SAML implementation doesn't use the `StateManager`. So there is no need to call invalidate after a successful SAML authentication. 

